### PR TITLE
Add ELB Account ID in other regions for S3 Bucket Policy

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Description: >-
   (SA0006) - 
   sagemaker-dashboards-for-ml: 
@@ -13,22 +13,22 @@ Parameters:
       constraints because it's used to name resources with restrictions (e.g. Amazon S3 bucket
       names cannot contain capital letters).
     AllowedPattern: '^[a-z0-9\-]+$'
-    ConstraintDescription: 'Only allowed to use lowercase letters, hyphens and/or numbers.'
+    ConstraintDescription: "Only allowed to use lowercase letters, hyphens and/or numbers."
   AddDevelopmentStack:
     Type: String
     Description: |
       Add stack for dashboard development?
       Contains Amazon SageMaker Notebook Instance and associated Amazon S3 Bucket.
-    Default: 'true'
-    AllowedValues: 
-      - 'true'
-      - 'false'
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
   SageMakerNotebookInstanceType:
     Description: |
       Choose the instance type for the Amazon SageMaker Notebook Instance.
       Will only be used if the development stack was added.
     Type: String
-    Default: 'ml.t3.medium'
+    Default: "ml.t3.medium"
   SageMakerNotebookGitRepository:
     Description: |
       Choose the Git repository to clone on the Amazon SageMaker Notebook Instance.
@@ -41,22 +41,22 @@ Parameters:
     Description: |
       Choose the Git user name to use for commits on the Amazon SageMaker Notebook Instance.
     Type: String
-    Default: 'SageMaker Default User'
-    AllowedPattern: '^.+$'
-    ConstraintDescription: 'Must not be blank.'
+    Default: "SageMaker Default User"
+    AllowedPattern: "^.+$"
+    ConstraintDescription: "Must not be blank."
   SageMakerNotebookGitUserEmail:
     Description: |
       Choose the Git user email to use for commits on the Amazon SageMaker Notebook Instance.
       Can be blank.
     Type: String
-    Default: ''
+    Default: ""
   CustomDomain:
     Type: String
     Description: |
       If you intend to host the deployed dashboard on a custom domain or sub-domain (e.g. dashboard.example.com), specify that here.
       Otherwise, leave this blank and the auto-generated Application Load Balancer DNS Name will be used instead.
       When specified, this will be used in authentication callbacks.
-    Default: ''
+    Default: ""
   ApplicationLoadBalancerSSLCertificate:
     Type: String
     Description: |
@@ -64,34 +64,34 @@ Parameters:
       specify the ARN of the AWS Certificate Manager certificate that should be used by the Application Load Balancer for HTTPS connections.
       Otherwise, leave this blank and a self-signed certificate be used instead, but be aware that this will lead to security warnings and should only
       be used for development purposes (not in production).
-    Default: ''
+    Default: ""
   ApplicationLoadBalancerCIDRWhitelist:
     Type: String
     Description: |
       Specify the CIDR IP address range that is allowed to access the dashboard (via the Application Load Balancer).
       Use http://checkip.amazonaws.com/ to find the IP address of your current machine.
       Only use '0.0.0.0/0' if public access is required.
-    Default: '0.0.0.0/0'
+    Default: "0.0.0.0/0"
     AllowedPattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
-    ConstraintDescription: 'Must be a valid CIDR IP.'
+    ConstraintDescription: "Must be a valid CIDR IP."
   ApplicationLoadBalancerStickySessions:
     Type: String
     Description: |
       Use sticky sessions to route all requests in a user session to the same dashboard server.
       Certain dashboard libraries may require this, but Streamlit does not.
-    Default: 'false'
-    AllowedValues: 
-      - 'true'
-      - 'false'
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
   AddCognitoAuthentication:
     Type: String
     Description: |
       Add Amazon Cognito authentication to dashboard?
       With authentication enabled, users access the dashboard with an individually assigned username and password.
-    Default: 'true'
-    AllowedValues: 
-      - 'true'
-      - 'false'
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
   CognitoAuthenticationSampleUserEmail:
     Type: String
     Description: |
@@ -101,8 +101,8 @@ Parameters:
       More users can be created through the Amazon Cognito Console or API.
       See the `CognitoUsersConsoleURL` output of this stack, for a link to the console where new users can be added.
     AllowedPattern: '^$|^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'
-    ConstraintDescription: 'Must be a valid email address.'
-    Default: ''
+    ConstraintDescription: "Must be a valid email address."
+    Default: ""
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -155,9 +155,16 @@ Metadata:
         default: Use Amazon Cognito Authentication?
       CognitoAuthenticationSampleUserEmail:
         default: Sample User Email
+Mappings:
+  AWSRegionArch2ELBAccountID:
+    ap-southeast-2:
+      id: 783225319266
+    us-west-2:
+      id: 797873946194
+
 Conditions:
-  AddDevelopmentStack: !Equals [ !Ref AddDevelopmentStack, 'true' ]
-  AddCognitoAuthentication: !Equals [ !Ref AddCognitoAuthentication, 'true' ]
+  AddDevelopmentStack: !Equals [!Ref AddDevelopmentStack, "true"]
+  AddCognitoAuthentication: !Equals [!Ref AddCognitoAuthentication, "true"]
 Resources:
   S3Bucket:
     Type: "AWS::S3::Bucket"
@@ -170,8 +177,7 @@ Resources:
         RestrictPublicBuckets: true
       BucketEncryption:
         ServerSideEncryptionConfiguration:
-          -
-            ServerSideEncryptionByDefault:
+          - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
     Metadata:
       cfn_nag:
@@ -180,32 +186,41 @@ Resources:
             reason: Avoids user having to manually create an Amazon S3 bucket for logs.
           - id: W51
             reason: Current default access policy is sufficient.
-  S3BucketPolicy: 
+  S3BucketPolicy:
     Type: AWS::S3::BucketPolicy
-    Properties: 
+    Properties:
       Bucket: !Ref S3Bucket
       PolicyDocument:
-        Statement: 
+        Statement:
           - Action: "s3:PutObject"
             Effect: "Allow"
             Resource: !Sub "arn:aws:s3:::${S3Bucket}/logs/AWSLogs/${AWS::AccountId}/*"
             Principal:
-              AWS: "arn:aws:iam::797873946194:root"
+              AWS: !Sub
+                - "arn:aws:iam::${ELB_ID}:root"
+                - {
+                    ELB_ID:
+                      !FindInMap [
+                        AWSRegionArch2ELBAccountID,
+                        !Ref "AWS::Region",
+                        id,
+                      ],
+                  }
           - Action: "s3:PutObject"
             Effect: "Allow"
             Resource: !Sub "arn:aws:s3:::${S3Bucket}/logs/AWSLogs/${AWS::AccountId}/*"
             Principal:
               Service: "delivery.logs.amazonaws.com"
             Condition:
-                StringEquals:
-                  s3:x-amz-acl: "bucket-owner-full-control"
+              StringEquals:
+                s3:x-amz-acl: "bucket-owner-full-control"
           - Action: "s3:GetBucketAcl"
             Effect: "Allow"
             Resource: !Sub "arn:aws:s3:::${S3Bucket}"
             Principal:
               Service: "delivery.logs.amazonaws.com"
   DevelopmentStack:
-    Type: 'AWS::CloudFormation::Stack'
+    Type: "AWS::CloudFormation::Stack"
     Condition: AddDevelopmentStack
     Properties:
       TemplateURL: ./development/development.yaml
@@ -224,7 +239,7 @@ Resources:
         AddCognitoAuthentication: !Ref AddCognitoAuthentication
         S3Bucket: !Ref S3Bucket
   DeploymentStack:
-    Type: 'AWS::CloudFormation::Stack'
+    Type: "AWS::CloudFormation::Stack"
     Properties:
       TemplateURL: ./deployment/deployment.yaml
       Parameters:
@@ -238,7 +253,7 @@ Resources:
         SageMakerModel: !Ref ResourceName
         S3Bucket: !Ref S3Bucket
   SolutionAssistant:
-    Type: 'AWS::CloudFormation::Stack'
+    Type: "AWS::CloudFormation::Stack"
     Properties:
       TemplateURL: ./assistants/solution-assistant/solution-assistant.yaml
       Parameters:
@@ -247,7 +262,7 @@ Resources:
         SageMakerModel: !GetAtt DeploymentStack.Outputs.SageMakerModel
         AddDevelopmentStack: !Ref AddDevelopmentStack
   S3BucketAssistant:
-    Type: 'AWS::CloudFormation::Stack'
+    Type: "AWS::CloudFormation::Stack"
     Properties:
       TemplateURL: ./assistants/bucket-assistant/bucket-assistant.yaml
       Parameters:

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -157,10 +157,56 @@ Metadata:
         default: Sample User Email
 Mappings:
   AWSRegionArch2ELBAccountID:
-    ap-southeast-2:
-      id: 783225319266
+    us-east-1:
+      id: 127311923021
+    us-east-2:
+      id: 33677994240
+    us-west-1:
+      id: 27434742980
     us-west-2:
       id: 797873946194
+    af-south-1:
+      id: 98369216593
+    ca-central-1:
+      id: 985666609251
+    eu-central-1:
+      id: 54676820928
+    eu-west-1:
+      id: 156460612806
+    eu-west-2:
+      id: 652711504416
+    eu-south-1:
+      id: 635631232127
+    eu-west-3:
+      id: 9996457667
+    eu-north-1:
+      id: 897822967062
+    ap-east-1:
+      id: 754344448648
+    ap-northeast-1:
+      id: 582318560864
+    ap-northeast-2:
+      id: 600734575887
+    ap-northeast-3:
+      id: 383597477331
+    ap-southeast-1:
+      id: 114774131450
+    ap-southeast-2:
+      id: 783225319266
+    ap-south-1:
+      id: 718504428378
+    me-south-1:
+      id: 76674570225
+    sa-east-1:
+      id: 507241528517
+    us-gov-west-1*:
+      id: 48591011584
+    us-gov-east-1*:
+      id: 190560391635
+    cn-north-1*:
+      id: 638102146993
+    cn-northwest-1*:
+      id: 37604701340
 
 Conditions:
   AddDevelopmentStack: !Equals [!Ref AddDevelopmentStack, "true"]

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -9,7 +9,9 @@ Our AWS CloudFormation template contains a number of custom resources, and each 
 pip install -r requirements.txt -t ./src/site-packages)
 (cd ./cloudformation/deployment/string-functions/ && \
 pip install -r requirements.txt -t ./src/site-packages)
-(cd ./cloudformation/solution-assistant && \
+(cd ./cloudformation/assistants/solution-assistant && \
+pip install -r requirements.txt -t ./src/site-packages)
+(cd ./cloudformation/assistants/bucket-assistant && \
 pip install -r requirements.txt -t ./src/site-packages)
 ```
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -16,7 +16,7 @@ pip install -r requirements.txt -t ./src/site-packages)
 Using the AWS Command Line Interface, we have a useful function called `package` that helps upload the AWS Lambda function's code and also any AWS CloudFormation nested stacks too. Make sure you replace `<s3-bucket>` and `<s3-prefix>` with an Amazon S3 bucket that you have created in your account.
 
 ```bash
-aws cloudformation package \
+aws --region us-west-2 cloudformation package \
 --template-file ./cloudformation/template.yaml \
 --s3-bucket <s3-bucket> \
 --s3-prefix <s3-prefix> \
@@ -25,7 +25,7 @@ aws cloudformation package \
 
 Add `--debug` if you have any issues at this stage. You can then use the `deploy` function to create the stack.
 
-```
+```bash
 aws cloudformation deploy \
 --stack-name sagemaker-ml-dashboards \
 --template-file ./build/packaged.yaml \
@@ -41,7 +41,7 @@ Sometimes you'll want to override the default parameters so add the following ar
 Any issues at this stage should be debugged by disabling AWS CloudFormation stack rollback and the `create-stack` command should be used instead of `deploy`.
 
 ```bash
-aws cloudformation create-stack \
+aws --region us-west-2 cloudformation create-stack \
 --stack-name sagemaker-ml-dashboards \
 --template-body file://./build/packaged.yaml \
 --capabilities CAPABILITY_IAM \


### PR DESCRIPTION
*Description of changes:*
- [x] Add ELB account ID CloudTemplate Mapping for different AWS Region
- [x] Set the right ELB ID in S3 bucket Policy per AWS Region
- [x] Update Doc and format 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
